### PR TITLE
Separate out ASPX vs HTML closing tags

### DIFF
--- a/AspxParser/AspxNode.cs
+++ b/AspxParser/AspxNode.cs
@@ -133,11 +133,38 @@ namespace AspxParser
             }
         }
 
-        public sealed class CloseTag : Located
+        public abstract class CloseTag : Located
+        {
+            protected CloseTag(Location location)
+                : base(location)
+            {
+            }
+        }
+
+        public sealed class CloseAspxTag : CloseTag
+        {
+            public string ControlName { get; }
+
+            public string Prefix { get; }
+
+            public CloseAspxTag(string prefix, string name, Location location)
+                : base(location)
+            {
+                ControlName = name;
+                Prefix = prefix;
+            }
+
+            public override T Accept<T>(IAspxVisitor<T> visitor)
+            {
+                return visitor.Visit(this);
+            }
+        }
+
+        public sealed class CloseHtmlTag : CloseTag
         {
             public string Name { get; }
 
-            public CloseTag(string name, Location location)
+            public CloseHtmlTag(string name, Location location)
                 : base(location)
             {
                 Name = name;

--- a/AspxParser/AspxOutputVisitor.cs
+++ b/AspxParser/AspxOutputVisitor.cs
@@ -20,9 +20,15 @@ namespace AspxParser
             return base.Visit(node);
         }
 
-        public override object Visit(AspxNode.CloseTag node)
+        public override object Visit(AspxNode.CloseHtmlTag node)
         {
             writer.Write("</" + node.Name + ">");
+            return base.Visit(node);
+        }
+
+        public override object Visit(AspxNode.CloseAspxTag node)
+        {
+            writer.Write("</" + node.Prefix + ":" + node.ControlName + ">");
             return base.Visit(node);
         }
 

--- a/AspxParser/AspxParser.cs
+++ b/AspxParser/AspxParser.cs
@@ -178,6 +178,7 @@ namespace AspxParser
                                 break;
                             }
                         }
+                        currentNode.AddChild(new AspxNode.CloseAspxTag(prefix, controlName, location));
                     }
                     else
                     {
@@ -191,8 +192,8 @@ namespace AspxParser
                                 break;
                             }
                         }
+                        currentNode.AddChild(new AspxNode.CloseHtmlTag(name, location));
                     }
-                    currentNode.AddChild(new AspxNode.CloseTag(name, location));
                     break;
                 }
 

--- a/AspxParser/DepthFirstAspxVisitor.cs
+++ b/AspxParser/DepthFirstAspxVisitor.cs
@@ -27,7 +27,12 @@
             return VisitChildren(node);
         }
 
-        public virtual T Visit(AspxNode.CloseTag node)
+        public virtual T Visit(AspxNode.CloseHtmlTag node)
+        {
+            return VisitChildren(node);
+        }
+
+        public virtual T Visit(AspxNode.CloseAspxTag node)
         {
             return VisitChildren(node);
         }

--- a/AspxParser/DepthFirstAspxWithoutCloseTagVisitor.cs
+++ b/AspxParser/DepthFirstAspxWithoutCloseTagVisitor.cs
@@ -37,7 +37,12 @@
             return VisitChildren(node);
         }
 
-        public T Visit(AspxNode.CloseTag node)
+        public T Visit(AspxNode.CloseHtmlTag node)
+        {
+            return default(T);
+        }
+
+        public T Visit(AspxNode.CloseAspxTag node)
         {
             return default(T);
         }

--- a/AspxParser/IAspxVisitor.cs
+++ b/AspxParser/IAspxVisitor.cs
@@ -7,7 +7,8 @@
         T Visit(AspxNode.SelfClosingHtmlTag node);
         T Visit(AspxNode.OpenAspxTag node);
         T Visit(AspxNode.SelfClosingAspxTag node);
-        T Visit(AspxNode.CloseTag node);
+        T Visit(AspxNode.CloseAspxTag node);
+        T Visit(AspxNode.CloseHtmlTag node);
         T Visit(AspxNode.AspxDirective node);
         T Visit(AspxNode.DataBinding node);
         T Visit(AspxNode.CodeRender node);


### PR DESCRIPTION
I was using this and found I wanted to easily disambiguate the ASPX vs HTML closing tags (ie have access to prefix). This adds a `CloseAspxTag` and `CloseHtmlTag` which derive from `CloseTag : Located`, with appropriate updates to the visitors.